### PR TITLE
Changed to make iptools use IPv4

### DIFF
--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/IPTool.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/IPTool.cs
@@ -30,7 +30,7 @@ namespace CodeSwine_Solo_Public_Lobby.Helpers
             string ip = "";
             try
             {
-                ip = new WebClient().DownloadString("http://icanhazip.com");
+                ip = new WebClient().DownloadString("http://ipv4.icanhazip.com");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Changed the URL to make the IPTools grab the IPv4 address related to these issues:
https://github.com/CodeSwine/GTA5Online-Private_Public_Lobby/issues/8
https://github.com/CodeSwine/GTA5Online-Private_Public_Lobby/issues/5