### PR TITLE
Adding IPv6 support

### DIFF
--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/DataAccess/DaWhitelist.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/DataAccess/DaWhitelist.cs
@@ -27,7 +27,7 @@ namespace CodeSwine_Solo_Public_Lobby.DataAccess
                 MWhitelist whitelist = JsonConvert.DeserializeObject<MWhitelist>(json);
                 foreach (string address in whitelist.Ips)
                 {
-                    if (IPTool.ValidateIPv4(address.ToString())) addresses.Add(IPAddress.Parse(address));
+                    if (IPTool.ValidateIP(address.ToString())) addresses.Add(IPAddress.Parse(address));
                 }
             }
             return addresses;

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/FirewallRule.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/FirewallRule.cs
@@ -1,11 +1,14 @@
 ﻿using NetFwTypeLib;
 using System;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace CodeSwine_Solo_Public_Lobby.Helpers
 {
     public class FirewallRule
     {
+        public static Label lblAdmin = null;
+
         /// <summary>
         /// Sets, Removes or Toggles CodeSwine Outbound firewall rules.
         /// </summary>
@@ -41,7 +44,10 @@ namespace CodeSwine_Solo_Public_Lobby.Helpers
             } catch (Exception e)
             {
                 ErrorLogger.LogException(e);
-                MessageBox.Show("Please start this program as administrator!");
+                if (lblAdmin != null)
+                    lblAdmin.Visibility = Visibility.Visible;
+                else
+                    MessageBox.Show("Please start this program as administrator!");
             }
         }
 
@@ -108,7 +114,10 @@ namespace CodeSwine_Solo_Public_Lobby.Helpers
             } catch (Exception e)
             {
                 ErrorLogger.LogException(e);
-                MessageBox.Show("Run this program as administrator!");
+                if (lblAdmin != null)
+                    lblAdmin.Visibility = Visibility.Visible;
+                else
+                    MessageBox.Show("Run this program as administrator!");
             }
         }
     }

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/IPTool.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/IPTool.cs
@@ -30,7 +30,7 @@ namespace CodeSwine_Solo_Public_Lobby.Helpers
             string ip = "";
             try
             {
-                ip = new WebClient().DownloadString("http://ipv6.icanhazip.com");
+                ip = new WebClient().DownloadString("https://ipv6.icanhazip.com");
             }
             catch (Exception e)
             {

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/IPTool.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/Helpers/IPTool.cs
@@ -30,7 +30,7 @@ namespace CodeSwine_Solo_Public_Lobby.Helpers
             string ip = "";
             try
             {
-                ip = new WebClient().DownloadString("http://ipv4.icanhazip.com");
+                ip = new WebClient().DownloadString("http://ipv6.icanhazip.com");
             }
             catch (Exception e)
             {
@@ -40,28 +40,27 @@ namespace CodeSwine_Solo_Public_Lobby.Helpers
             return ip;
         }
 
-        /// <summary>
-        /// Validates IP Address.
-        /// </summary>
-        /// <param name="ipString"></param>
-        /// <returns>Bool True or False.</returns>
-        public static bool ValidateIPv4(string ipString)
+        public static bool ValidateIP(string ipString)
         {
             if (String.IsNullOrWhiteSpace(ipString))
             {
                 return false;
             }
 
-            string[] splitValues = ipString.Split('.');
-
-            if (splitValues.Length != 4)
+            IPAddress address;
+            if (IPAddress.TryParse(ipString, out address))
             {
-                return false;
+                switch (address.AddressFamily)
+                {
+                    case System.Net.Sockets.AddressFamily.InterNetwork:
+                        // we have IPv4 
+                        return true;
+                    case System.Net.Sockets.AddressFamily.InterNetworkV6:
+                        // we have IPv6
+                        return true;
+                }
             }
-
-            byte tempForParsing;
-
-            return splitValues.All(r => byte.TryParse(r, out tempForParsing));
+            return false;
         }
     }
 }

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml
@@ -21,7 +21,7 @@
         </Grid.RowDefinitions>
 
         <!-- Row 0 -->
-        <Label x:Name="lblYourIPAddress" Content="Your IP Address is:" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="572" FontSize="24" Height="38" FontWeight="SemiBold" Foreground="#FF707C80" Grid.ColumnSpan="2"/>
+        <Label x:Name="lblYourIPAddress" Content="Your IP Address is:" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="897" FontSize="24" Height="38" FontWeight="SemiBold" Foreground="#FF707C80" Grid.ColumnSpan="3"/>
         <Border x:Name="brdYourIPAddress" BorderBrush="#FF707C80" BorderThickness="1" Grid.ColumnSpan="3" HorizontalAlignment="Left" Height="1" Margin="10,48,0,0" VerticalAlignment="Top" Width="888"/>
 
         <!-- Row 1 & 2 -->

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml
@@ -95,5 +95,6 @@
         <Image x:Name="image6_Copy" Grid.Column="2" HorizontalAlignment="Left" Height="42" Margin="14,8,0,0" Grid.Row="2" VerticalAlignment="Top" Width="42" Source="ImageResources/5mods.jpg"/>
         <Label x:Name="label2_Copy1" Content="gta5-mods.com/users/CodeSwine" Grid.Column="2" HorizontalAlignment="Left" Margin="56,16,0,0" Grid.Row="2" VerticalAlignment="Top" Width="226" Foreground="#FF707C80"/>
         <Label x:Name="label3" Content="Hotkey: CTRL+F10 to toggle." HorizontalAlignment="Left" Margin="10,0,0,0" Grid.Row="3" VerticalAlignment="Top" Height="28" Width="276" FontWeight="Bold" Foreground="#FF707C80"/>
+        <Label x:Name="lblAdmin" Content="Please start this program as administrator!" Foreground="Red" Visibility="Hidden" Grid.Column="1" HorizontalAlignment="Left" Margin="11,0,0,0" Grid.Row="3" VerticalAlignment="Top" RenderTransformOrigin="0.196,0.126"/>
     </Grid>
 </Window>

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml.cs
@@ -39,6 +39,7 @@ namespace CodeSwine_Solo_Public_Lobby
 
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
+            FirewallRule.lblAdmin = lblAdmin;
             Init();
         }
 

--- a/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml.cs
+++ b/CodeSwine-Solo_Public_Lobby/CodeSwine-Solo_Public_Lobby/MainWindow.xaml.cs
@@ -56,7 +56,7 @@ namespace CodeSwine_Solo_Public_Lobby
 
         private void btnAdd_Click(object sender, RoutedEventArgs e)
         {
-            if(IPTool.ValidateIPv4(txbIpToAdd.Text))
+            if(IPTool.ValidateIP(txbIpToAdd.Text))
             {
                 if(!addresses.Contains(IPAddress.Parse(txbIpToAdd.Text)))
                 {


### PR DESCRIPTION
There's no real reason this program shouldn't be able to use IPv6, since the majority of the code doesn't even have to change, and it better future-proofs it.
### Changes
* Switched the icanhazip to `ipv6.icanhazip` 
* Extended the text box to fit the longer text
* Switched IP validation to IPv4 or IPv6 (copied from StackOverflow somewhere)

### Additions
* A label with red text instead of a message box to inform the user to run the program in administrator mode

My reasoning for this is that the message boxes appear in the primary monitor, so if the program is in another monitor or not focused, the message box is not really visible. Whereas having text appear on the program is more visible.

Alternatively, *not* removing the message box and just adding the text is also an easy option.